### PR TITLE
Add CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,28 @@
+name: CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    env:
+      NEXT_TELEMETRY_DISABLED: '1'
+      NEXT_DISABLE_FONT_DOWNLOAD: '1'
+    steps:
+      - uses: actions/checkout@v3
+      - name: Use Node.js 20
+        uses: actions/setup-node@v3
+        with:
+          node-version: '20'
+          cache: 'npm'
+      - name: Install dependencies
+        run: npm ci
+      - name: Lint
+        run: npm run lint
+      - name: Type check
+        run: npx tsc --noEmit
+      - name: Build
+        run: npm run build


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to lint, type check and build

## Testing
- `npm run lint`
- `npx tsc --noEmit`
- *(build fails locally due to font download issue)*

------
https://chatgpt.com/codex/tasks/task_e_6846e9af56688323892d18ea473f5f56